### PR TITLE
Fix type for keeping producerNode and consumerNode in BaseLinkedQueueProducerNodeRef

### DIFF
--- a/rxjava-proguard-rules/proguard-rules.txt
+++ b/rxjava-proguard-rules/proguard-rules.txt
@@ -6,6 +6,6 @@
 }
 
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
-   long producerNode;
-   long consumerNode;
+   rx.internal.util.atomic.LinkedQueueNode producerNode;
+   rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }


### PR DESCRIPTION
Closes #16.
