### PR TITLE
Fix rules for BaseLinkedQueueConsumerNodeRef and BaseLinkedQueueProducerNodeRef again

### DIFF
--- a/rxjava-proguard-rules/proguard-rules.txt
+++ b/rxjava-proguard-rules/proguard-rules.txt
@@ -6,6 +6,9 @@
 }
 
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
-   rx.internal.util.atomic.LinkedQueueNode producerNode;
-   rx.internal.util.atomic.LinkedQueueNode consumerNode;
+    rx.internal.util.atomic.LinkedQueueNode producerNode;
+}
+
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }


### PR DESCRIPTION
See #16.
