### PR TITLE
Add field that is modified by an AtomicIntegerFieldUpdater

### DIFF
--- a/rxjava-proguard-rules/proguard-rules.txt
+++ b/rxjava-proguard-rules/proguard-rules.txt
@@ -12,3 +12,7 @@
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
     rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }
+
+-keepclassmembers class rx.schedulers.CachedThreadScheduler$EventLoopWorker {
+    volatile int once;
+}


### PR DESCRIPTION
The new Proguard-less shrinker from the Android plugin 2.0.0 seems to delete or rename this field. Add a rule to keep it.
