### PR TITLE
suppress note for PlatformDependent

### DIFF
--- a/rxjava-proguard-rules/proguard-rules.txt
+++ b/rxjava-proguard-rules/proguard-rules.txt
@@ -12,3 +12,5 @@
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
     rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }
+
+-dontnote rx.internal.util.PlatformDependent


### PR DESCRIPTION
That rule suppess following message:
>Note: rx.internal.util.PlatformDependent accesses a field 'SDK_INT' dynamically
       Maybe this is library field 'android.os.Build$VERSION { int SDK_INT; }'